### PR TITLE
Can properly execute node on windows

### DIFF
--- a/lib/isIojs.js
+++ b/lib/isIojs.js
@@ -12,5 +12,5 @@ module.exports = (function () {
   if (~[ 'v1.0.0', 'v1.0.1' ].indexOf(process.version)) {
     return true;
   }
-  return /iojs\.org/.test(cp.execSync(process.execPath + ' -h', { encoding: 'ascii' }));
+  return /iojs\.org/.test(cp.execSync('"' + process.execPath + '" -h', { encoding: 'ascii' }));
 })();


### PR DESCRIPTION
Hi,

Need to quote the path because on windows it includes spaces.

So this
C:\Program Files\nodejs\node.exe -h
should be executed as 
"C:\Program Files\nodejs\node.exe" -h

Should be OK in a Unix shell.

Thanks
